### PR TITLE
The price is no longer converted to pennies, cents, etc. (BC break)

### DIFF
--- a/src/Comgate.php
+++ b/src/Comgate.php
@@ -4,6 +4,8 @@ namespace Contributte\Comgate;
 
 class Comgate
 {
+	/** @var string */
+	const API_GATEWAY = 'https://payments.comgate.cz/v1.0/';
 
 	/** @var string */
 	private $merchant;

--- a/src/DI/ComgateExtension.php
+++ b/src/DI/ComgateExtension.php
@@ -21,7 +21,7 @@ class ComgateExtension extends CompilerExtension
 	public function getConfigSchema(): Schema
 	{
 		return Expect::structure([
-			'gateway' => Expect::string()->default('https://payments.comgate.cz/v1.0/'),
+			'gateway' => Expect::string()->default(Comgate::API_GATEWAY),
 			'merchant' => Expect::string()->required(),
 			'secret' => Expect::string()->required(),
 			'test' => Expect::bool()->default(true),

--- a/src/DI/ComgateExtension24.php
+++ b/src/DI/ComgateExtension24.php
@@ -8,15 +8,13 @@ use Contributte\Comgate\Http\HttpClient;
 use GuzzleHttp\Client;
 use Nette\DI\CompilerExtension;
 use Nette\DI\Statement;
-use Nette\Schema\Expect;
-use Nette\Schema\Schema;
 
 class ComgateExtension24 extends CompilerExtension
 {
 
 	/** @var mixed[] */
 	protected $defaults = [
-		'gateway' => 'https://payments.comgate.cz/v1.0/',
+		'gateway' => Comgate::API_GATEWAY,
 		'merchant' => null,
 		'secret' => null,
 		'test' => true,

--- a/src/Entity/Payment.php
+++ b/src/Entity/Payment.php
@@ -76,7 +76,7 @@ class Payment extends AbstractEntity
 	): self
 	{
 		$p = new static();
-		$p->price = $price * 100;
+		$p->price = $price;
 		$p->curr = $curr;
 		$p->label = $label;
 		$p->refId = $refId;


### PR DESCRIPTION
- Now it is possible to pay the price including pennies
- API Gateway was moved to the class constant
- Unused imports were removed

Related to #2 