### PR TITLE
Payments outside the Czech Republic (fix country and lang)

### DIFF
--- a/src/Entity/Codes/LangCode.php
+++ b/src/Entity/Codes/LangCode.php
@@ -7,8 +7,10 @@ namespace Contributte\Comgate\Entity\Codes;
  */
 final class LangCode
 {
+
 	public const CS = 'cs';
 	public const SK = 'sk';
 	public const EN = 'en';
 	public const PL = 'pl';
+	
 }

--- a/src/Entity/Codes/LangCode.php
+++ b/src/Entity/Codes/LangCode.php
@@ -2,15 +2,12 @@
 
 namespace Contributte\Comgate\Entity\Codes;
 
-/**
- * Supported lang code by ISO 639-1
- */
 final class LangCode
 {
 
-    public const CS = 'cs';
-    public const SK = 'sk';
-    public const EN = 'en';
-    public const PL = 'pl';
-    
+	public const CS = 'cs';
+	public const SK = 'sk';
+	public const EN = 'en';
+	public const PL = 'PL';
+
 }

--- a/src/Entity/Codes/LangCode.php
+++ b/src/Entity/Codes/LangCode.php
@@ -8,9 +8,9 @@ namespace Contributte\Comgate\Entity\Codes;
 final class LangCode
 {
 
-	public const CS = 'cs';
-	public const SK = 'sk';
-	public const EN = 'en';
-	public const PL = 'pl';
-	
+    public const CS = 'cs';
+    public const SK = 'sk';
+    public const EN = 'en';
+    public const PL = 'pl';
+    
 }

--- a/src/Entity/Codes/LangCode.php
+++ b/src/Entity/Codes/LangCode.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Comgate\Entity\Codes;
+
+/**
+ * Supported lang code by ISO 639-1
+ */
+final class LangCode
+{
+	public const CS = 'cs';
+	public const SK = 'sk';
+	public const EN = 'en';
+	public const PL = 'pl';
+}

--- a/src/Entity/Payment.php
+++ b/src/Entity/Payment.php
@@ -3,6 +3,7 @@
 namespace Contributte\Comgate\Entity;
 
 use Contributte\Comgate\Entity\Codes\CountryCode;
+use Contributte\Comgate\Entity\Codes\LangCode;
 use Contributte\Comgate\Entity\Codes\PaymentMethodCode;
 use Contributte\Comgate\Exceptions\Logical\InvalidArgumentException;
 
@@ -12,7 +13,7 @@ class Payment extends AbstractEntity
 	/** @var float */
 	private $price;
 
-	/** @var string */
+	/** @var string ISO 4217 */
 	private $curr;
 
 	/** @var string */
@@ -42,8 +43,8 @@ class Payment extends AbstractEntity
 	/** @var string */
 	private $name;
 
-	/** @var string */
-	private $lang;
+	/** @var string ISO 639-1 */
+	private $lang = LangCode::CS;
 
 	/** @var bool */
 	private $prepareOnly;
@@ -77,7 +78,8 @@ class Payment extends AbstractEntity
 		string $refId,
 		string $email,
 		string $method = PaymentMethodCode::ALL,
-		string $country = CountryCode::ALL
+		string $country = CountryCode::ALL,
+		string $lang = LangCode::CS
 	): self
 	{
 		if ($price !== round($price, 2)) {
@@ -92,6 +94,7 @@ class Payment extends AbstractEntity
 		$p->email = $email;
 		$p->method = $method;
 		$p->country = $country;
+		$p->lang = $lang;
 		$p->prepareOnly = true;
 
 		return $p;
@@ -271,6 +274,8 @@ class Payment extends AbstractEntity
 			'method' => $this->method,
 			'email' => $this->email,
 			'prepareOnly' => $this->prepareOnly ? 'true' : 'false',
+			'country' => $this->country,
+			'lang' => $this->lang,
 		];
 	}
 


### PR DESCRIPTION
Create payments by PaymentService::create() is not sending Payment::country. Comgate uses "CZ" as default, that not work for EUR payments (by VÚB Banka SK). This fix is backward compatible.

Create payments by PaymentService::create() doesn't support lang parameter, that is necessary for payments outside the Czech Republic (Comgate forms are talking by preset lang). This extension is 
backward compatible.