### PR TITLE
Update docs: section configuration

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -23,7 +23,7 @@ extensions:
 
 ```yaml
 comgate:
-    merchant: 12345678
+    merchant: "12345678"
     secret: foobar
     test: true/false
 ```


### PR DESCRIPTION
Merchant number must be in quotes. Otherwise get exception: The option 'comgate › merchant' expects to be string, int 12345678 given.