### PR TITLE
Set guzzlehttp/guzzle with carret dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "php": "^7.2|^8.0",
     "brick/money": "^0.5.0",
-    "guzzlehttp/guzzle": "6.3.3|^7.0",
+    "guzzlehttp/guzzle": "^6.3.3|^7.0",
     "guzzlehttp/psr7": "^1.7"
   },
   "require-dev": {


### PR DESCRIPTION
The comgate package is locked to too specific version of `guzzlehttp/guzzle`.