### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

Replace the `coverage` target in `Makefile` to run Tester with `php` instead of `phpdbg`.

## Motivation

This aligns `contributte/comgate` with contributte/contributte#73 so coverage runs no longer depend on `phpdbg`.

## Changes

- switch both `coverage` target variants from `-p phpdbg` to `-p php`

## Testing

- [x] `make coverage` attempted locally
- [ ] Coverage run completes locally
- [ ] CI passes

Local blocker: on PHP 8.5.3, `make coverage` currently fails inside `nette/tester` with `Using null as an array offset is deprecated` in `vendor/nette/tester/src/Framework/Dumper.php:422` before coverage output is produced.